### PR TITLE
ユーザーはTODOを続けて追加したい #15

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,6 +6,7 @@
 
     <input
       v-model="newTaskTitle"
+      v-on:keyup.enter="addTask"
       class="shadow appearance-none border rounded py-2 px-3 text-gray-600 my-4"
       type="text"
       name="task-title"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,7 +43,7 @@ export default {
   }),
   methods: {
     addTask() {
-      if (this.newTaskTitle != '') {
+      if (this.newTaskTitle !== '') {
         this.tasks.push({
           title: this.newTaskTitle
         })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
     <input
       v-model="newTaskTitle"
       ref="inputTask"
-      v-on:keyup.enter="addTask"
+      v-on:keydown.enter="addTask"
       class="shadow appearance-none border rounded py-2 px-3 text-gray-600 my-4"
       type="text"
       name="task-title"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,6 +6,7 @@
 
     <input
       v-model="newTaskTitle"
+      ref="inputTask"
       v-on:keyup.enter="addTask"
       class="shadow appearance-none border rounded py-2 px-3 text-gray-600 my-4"
       type="text"
@@ -42,10 +43,13 @@ export default {
   }),
   methods: {
     addTask() {
-      this.tasks.push({
-        title: this.newTaskTitle
-      })
-      this.newTaskTitle = ''
+      if (this.newTaskTitle != '') {
+        this.tasks.push({
+          title: this.newTaskTitle
+        })
+        this.newTaskTitle = ''
+      }
+      this.$refs.inputTask.focus()
     }
   }
 }


### PR DESCRIPTION
### 対応するissue：

　ユーザーはTODOを続けて追加したい #15

### 変更内容：

　・エンターキーで付箋を追加できるようにした
　・付箋追加後、入力していたテキストをクリアして、続けて次の付箋を入力できるようにした

　-指摘後追加-
　・日本語変換時、エンターキーを押下してもタスクが追加されないようにした
　・タスク入力欄が初期値のときの比較演算子を変更

### 確認方法：

　・VercelのPreviewで、以下のとおりであること
　　①エンターキーで付箋が追加できる
　　②付箋追加後、続けて次の付箋を入力できる

　    -指摘後追加-
　    ③日本語変換時、エンターキーを押下してもタスクが追加されない

　　https://todo-practice-git-feature-15addcontinuouslytodo.slc-agilers.now.sh
