### PR TITLE
ユーザーはTODOを編集したい #4

### DIFF
--- a/components/list.vue
+++ b/components/list.vue
@@ -23,20 +23,12 @@
         v-for="task in tasks"
         class="py-2 px-8 border border-gray-400 text-gray-600 mx-auto w-1/2 text-left flex"
       >
-        <div
-          v-if="!task.edit"
-          v-text="task.title"
-          v-on:click="task.edit = true"
-          class="inline-block flex-auto py-2"
-        ></div>
         <input
-          v-if="task.edit"
-          v-auto-focus
-          type="text"
+          ref="inputTitle"
           v-model="task.title"
-          @blur="task.edit = false"
-          @keydown.enter="task.edit = false"
-          class="inline-block flex-auto px-2 py-2 block shadow appearance-none border rounded text-gray-600 w-1/2 mx-auto"
+          type="text"
+          @keydown.enter="focusOut(task)"
+          class="inline-block flex-auto px-2 py-2 block focus:shadow appearance-none focus:border focus:rounded text-gray-600 w-1/2 mx-auto"
         />
         <button
           class="inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -53,7 +45,8 @@
 export default {
   props: ['tasks'],
   data: () => ({
-    newTaskTitle: ''
+    newTaskTitle: '',
+    index: ''
   }),
   methods: {
     addTask(clickevent) {
@@ -63,6 +56,10 @@ export default {
     },
     displayDetail(task) {
       this.$emit('task-button-click', task)
+    },
+    focusOut(task) {
+      this.index = this.tasks.indexOf(task)
+      this.$refs.inputTitle[this.index].blur()
     }
   }
 }

--- a/components/list.vue
+++ b/components/list.vue
@@ -21,13 +21,13 @@
     <ul>
       <li
         v-for="task in tasks"
-        class="py-2 px-8 border border-gray-400 text-gray-600 mx-auto w-1/2 text-left"
+        class="py-2 px-8 border border-gray-400 text-gray-600 mx-auto w-1/2 text-left flex"
       >
         <div
           v-if="!task.edit"
           v-text="task.title"
           v-on:click="task.edit = true"
-          class="inline-block"
+          class="inline-block flex-auto py-2"
         ></div>
         <input
           v-if="task.edit"
@@ -36,7 +36,7 @@
           v-model="task.title"
           @blur="task.edit = false"
           @keydown.enter="task.edit = false"
-          class="inline-block"
+          class="inline-block flex-auto px-2 py-2 block shadow appearance-none border rounded text-gray-600 w-1/2 mx-auto"
         />
         <button
           class="inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/components/list.vue
+++ b/components/list.vue
@@ -21,13 +21,28 @@
     <ul>
       <li
         v-for="task in tasks"
-        class="py-2 px-8 border border-gray-400 text-gray-600 mx-auto w-64"
+        class="py-2 px-8 border border-gray-400 text-gray-600 mx-auto w-1/2 text-left"
       >
+        <div
+          v-if="!task.edit"
+          v-text="task.title"
+          v-on:click="task.edit = true"
+          class="inline-block"
+        ></div>
+        <input
+          v-if="task.edit"
+          v-auto-focus
+          type="text"
+          v-model="task.title"
+          @blur="task.edit = false"
+          @keydown.enter="task.edit = false"
+          class="inline-block"
+        />
         <button
-          class="text-blue-400 hover:text-blue-700"
+          class="inline-block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           @click="displayDetail(task)"
         >
-          {{ task.title }}
+          詳細
         </button>
       </li>
     </ul>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -29,23 +29,19 @@ export default {
       tasks: [
         {
           title: '仮タスクタイトル1',
-          detail: '仮タスクタイトル1詳細',
-          edit: false
+          detail: '仮タスクタイトル1詳細'
         },
         {
           title: '仮タスクタイトル2',
-          detail: '仮タスクタイトル2詳細',
-          edit: false
+          detail: '仮タスクタイトル2詳細'
         },
         {
           title: '仮タスクタイトル3',
-          detail: '仮タスクタイトル3詳細',
-          edit: false
+          detail: '仮タスクタイトル3詳細'
         },
         {
           title: '仮タスクタイトル4',
-          detail: '仮タスクタイトル4詳細',
-          edit: false
+          detail: '仮タスクタイトル4詳細'
         }
       ],
       selectedTask: { title: '', detail: '' }
@@ -55,8 +51,7 @@ export default {
     addTask(newTaskTitle) {
       if (newTaskTitle !== '') {
         this.tasks.push({
-          title: newTaskTitle,
-          edit: false
+          title: newTaskTitle
         })
       }
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,10 +27,26 @@ export default {
     return {
       currentView: 'list',
       tasks: [
-        { title: '仮タスクタイトル1', detail: '仮タスクタイトル1詳細' },
-        { title: '仮タスクタイトル2', detail: '仮タスクタイトル2詳細' },
-        { title: '仮タスクタイトル3', detail: '仮タスクタイトル3詳細' },
-        { title: '仮タスクタイトル4', detail: '仮タスクタイトル4詳細' }
+        {
+          title: '仮タスクタイトル1',
+          detail: '仮タスクタイトル1詳細',
+          edit: false
+        },
+        {
+          title: '仮タスクタイトル2',
+          detail: '仮タスクタイトル2詳細',
+          edit: false
+        },
+        {
+          title: '仮タスクタイトル3',
+          detail: '仮タスクタイトル3詳細',
+          edit: false
+        },
+        {
+          title: '仮タスクタイトル4',
+          detail: '仮タスクタイトル4詳細',
+          edit: false
+        }
       ],
       selectedTask: { title: '', detail: '' }
     }
@@ -39,7 +55,8 @@ export default {
     addTask(newTaskTitle) {
       if (newTaskTitle !== '') {
         this.tasks.push({
-          title: newTaskTitle
+          title: newTaskTitle,
+          edit: false
         })
       }
     },


### PR DESCRIPTION
### 対応するissue：

　ユーザーはTODOを編集したい #4 


### 変更内容：

　・一覧画面から詳細画面に遷移する方法をタイトルにリンクを貼る→ボタンを押下に変更した
　・ 一覧画面のタイトルをクリックしたときに編集状態にした
　・一覧画面のタイトル編集時にフォーカスを外すか、
　　エンターキーを押したときに編集を完了させるようにした
　・詳細画面でタイトルと説明を編集できるようにした
　・一覧画面の見た目をtailwindcssで整えた


### 確認方法：

　・VercelのPreviewで以下を確認ください。
　　①一覧から付箋のタイトルを編集できること
　　②詳細画面から付箋のタイトルと説明を編集できること
　　　https://todo-practice-git-feature-4edittodo.slc-agilers.now.sh